### PR TITLE
Fixed error in sample size checks

### DIFF
--- a/library/analyses.py
+++ b/library/analyses.py
@@ -323,7 +323,7 @@ class Analyzer:
         groupedtable = table.groupby(analysis) if analysis else table
 
         # make table with groups >= 2 for some analyses
-        small_groups = groupedtable.transform(lambda group: group.count() < 2).iloc[:, 0]
+        small_groups = groupedtable.transform(lambda group: group.count() >= 2).iloc[:, 0]
         groupedtable_filtered = table.loc[small_groups].groupby(analysis) if analysis else table.loc[small_groups]
         if len(groupedtable_filtered.groups) < 2:
             groupedtable_filtered = None


### PR DESCRIPTION
I had made a stupid mistake and wrote '< 2' instead of '>= 2'. Now the small groups should be rejected correctly

Closes #25.